### PR TITLE
fix(install): Populate execution requests

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -222,6 +222,7 @@
                     </dependency>
                 </dependencies>
                 <configuration>
+					<skipInvocation>${skipTests}</skipInvocation>
                     <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                     <settingsFile>src/it/settings.xml</settingsFile>
                     <localRepositoryPath>${project.build.directory}/local-repo

--- a/plugin/src/it/project-with-invalid-parent-in-store/pom.xml
+++ b/plugin/src/it/project-with-invalid-parent-in-store/pom.xml
@@ -12,6 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven-install-plugin.version>3.1.1</maven-install-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -23,6 +24,14 @@
 	</dependencies>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-install-plugin</artifactId>
+					<version>${maven-install-plugin.version}</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.bonitasoft.maven</groupId>

--- a/plugin/src/test/java/org/bonitasoft/plugin/install/InstallProjectStoreMojoTest.java
+++ b/plugin/src/test/java/org/bonitasoft/plugin/install/InstallProjectStoreMojoTest.java
@@ -15,30 +15,198 @@
 package org.bonitasoft.plugin.install;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+import java.io.File;
+
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.bridge.MavenRepositorySystem;
+import org.apache.maven.execution.DefaultMavenExecutionRequestPopulator;
+import org.apache.maven.execution.MavenExecutionRequestPopulator;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.version.PluginVersionRequest;
+import org.apache.maven.plugin.version.PluginVersionResolutionException;
+import org.apache.maven.plugin.version.PluginVersionResolver;
+import org.apache.maven.plugin.version.PluginVersionResult;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Mirror;
+import org.apache.maven.settings.Settings;
+import org.eclipse.aether.repository.ArtifactRepository;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class InstallProjectStoreMojoTest {
+
+    MavenExecutionRequestPopulator populator = new DefaultMavenExecutionRequestPopulator(new MavenRepositorySystem());
+
+    @Mock
+    MavenSession session;
     
+    @Mock
+    PluginVersionResolver pluginVersionResolver;
+
     @Test
     void should_return_file_extension() throws Exception {
         String extension = InstallProjectStoreMojo.getExtension("lib.jar");
-        
+
         assertThat(extension).isEqualTo("jar");
     }
-    
+
     @Test
     void should_return_null_file_extension_when_name_ending_with_a_dot() throws Exception {
         String extension = InstallProjectStoreMojo.getExtension("lib.");
-        
-        assertThat(extension).isNull();
-    }
-    
-    @Test
-    void should_return_null_file_extension() throws Exception {
-        String extension = InstallProjectStoreMojo.getExtension("lib");
-        
+
         assertThat(extension).isNull();
     }
 
+    @Test
+    void should_return_null_file_extension() throws Exception {
+        String extension = InstallProjectStoreMojo.getExtension("lib");
+
+        assertThat(extension).isNull();
+    }
+
+    @Test
+    void should_create_an_install_file_execution_request() throws Exception {
+        var mojo = new InstallProjectStoreMojo();
+        mojo.execRequestPopulator = populator;
+        mojo.session = session;
+        var artifact = new DefaultArtifact("g", "a", "v", null, "jar", null, new DefaultArtifactHandler("jar"));
+
+        File artifactFile = new File("artifact.jar");
+        var request = mojo.newInstallFileExecutionRequest(artifact, artifactFile, null, "3.0.0");
+
+        assertThat(request.getGoals()).containsOnly("org.apache.maven.plugins:maven-install-plugin:3.0.0:install-file");
+        assertThat(request.getUserProperties()).containsEntry("groupId", "g")
+                .containsEntry("artifactId", "a")
+                .containsEntry("version", "v")
+                .containsEntry("file", artifactFile.getAbsolutePath())
+                .containsEntry("packaging", "jar");
+    }
+    
+    @Test
+    void should_create_an_install_file_execution_request_with_classifier() throws Exception {
+        var mojo = new InstallProjectStoreMojo();
+        mojo.execRequestPopulator = populator;
+        mojo.session = session;
+        var artifact = new DefaultArtifact("g", "a", "v", null, "jar", "sources", new DefaultArtifactHandler("jar"));
+
+        File artifactFile = new File("artifact.jar");
+        var request = mojo.newInstallFileExecutionRequest(artifact, artifactFile, null, "3.0.0");
+
+        assertThat(request.getUserProperties()).containsEntry("groupId", "g")
+                .containsEntry("artifactId", "a")
+                .containsEntry("version", "v")
+                .containsEntry("classifier", "sources")
+                .containsEntry("file", artifactFile.getAbsolutePath())
+                .containsEntry("packaging", "jar");
+    }
+    
+    @Test
+    void should_create_an_install_file_execution_request_with_pom() throws Exception {
+        var mojo = new InstallProjectStoreMojo();
+        mojo.execRequestPopulator = populator;
+        mojo.session = session;
+        var artifact = new DefaultArtifact("g", "a", "v", null, "jar", null, new DefaultArtifactHandler("jar"));
+
+        File artifactFile = new File("artifact.jar");
+        File pomFile = new File("pom.xml");
+        var request = mojo.newInstallFileExecutionRequest(artifact, artifactFile, pomFile, "3.0.0");
+
+        assertThat(request.getUserProperties()).containsEntry("groupId", "g")
+                .containsEntry("artifactId", "a")
+                .containsEntry("version", "v")
+                .containsEntry("pomFile", pomFile.getAbsolutePath())
+                .containsEntry("file", artifactFile.getAbsolutePath())
+                .containsEntry("packaging", "jar");
+    }
+    
+    @Test
+    void should_create_an_install_file_execution_request_populated_with_sessions_setttings() throws Exception {
+        var mojo = new InstallProjectStoreMojo();
+        mojo.execRequestPopulator = populator;
+        var settings = new Settings();
+        var mirror = new Mirror();
+        mirror.setId("test-mirror");
+        mirror.setMirrorOf("*");
+        mirror.setUrl("http://test-mirror.net");
+        settings.addMirror(mirror);
+        when(session.getSettings()).thenReturn(settings);
+        mojo.session = session;
+        var artifact = new DefaultArtifact("g", "a", "v", null, "jar", null, new DefaultArtifactHandler("jar"));
+
+        File artifactFile = new File("artifact.jar");
+        File pomFile = new File("pom.xml");
+        var request = mojo.newInstallFileExecutionRequest(artifact, artifactFile, pomFile, "3.0.0");
+
+        assertThat(request.getMirrors()).extracting("id").contains("test-mirror");
+    }
+    
+    @Test
+    void should_use_the_default_install_plugin_version() throws Exception {
+        var mojo = new InstallProjectStoreMojo();
+        mojo.pluginVersionResolver = pluginVersionResolver;
+        mojo.project =  new MavenProject();
+        var result = new PluginVersionResult() {
+            
+            @Override
+            public String getVersion() {
+                return InstallProjectStoreMojo.INITIAL_INSTALL_PLUGIN_VERSION;
+            }
+            
+            @Override
+            public ArtifactRepository getRepository() {
+                return null;
+            }
+        };
+        when(pluginVersionResolver.resolve(any(PluginVersionRequest.class))).thenReturn(result);
+        mojo.session = session;
+        var version = mojo.computeMavenInstallPluginVersion();
+
+        assertThat(version).isEqualTo(InstallProjectStoreMojo.DEFAULT_INSTALL_PLUGIN_VERSION);
+    }
+    
+    @Test
+    void should_use_the_project_defined_install_plugin_version() throws Exception {
+        var mojo = new InstallProjectStoreMojo();
+        mojo.pluginVersionResolver = pluginVersionResolver;
+        mojo.project =  new MavenProject();
+        var result = new PluginVersionResult() {
+            
+            @Override
+            public String getVersion() {
+                return "3.1.1";
+            }
+            
+            @Override
+            public ArtifactRepository getRepository() {
+                return null;
+            }
+        };
+        when(pluginVersionResolver.resolve(any(PluginVersionRequest.class))).thenReturn(result);
+        mojo.session = session;
+        var version = mojo.computeMavenInstallPluginVersion();
+
+        assertThat(version).isEqualTo("3.1.1");
+    }
+    
+    @Test
+    void should_throw_MojoExecutionException_when_plugin_version_resolution_fails() throws Exception {
+        var mojo = new InstallProjectStoreMojo();
+        mojo.pluginVersionResolver = pluginVersionResolver;
+        mojo.project =  new MavenProject();
+        when(pluginVersionResolver.resolve(any(PluginVersionRequest.class))).thenThrow(new PluginVersionResolutionException("org.apache.maven.plugins", "maven-install-plugin", "2.4"));
+        mojo.session = session;
+        
+        assertThrows(MojoExecutionException.class, () -> mojo.computeMavenInstallPluginVersion());
+    }
+    
+    
 }


### PR DESCRIPTION
Fill the execution request of the install-file invocation with the session settings to retrieve proxies, mirrors and repositories configuration.