### PR TITLE
fix(lombok): use provided scope

### DIFF
--- a/report-model/pom.xml
+++ b/report-model/pom.xml
@@ -23,8 +23,7 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.28</version>
-      <scope>compile</scope>
-      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
     <!-- Test -->
     <dependency>


### PR DESCRIPTION
Use provided scope to avoid retrieving lombok transitively