### PR TITLE
fix(analyze): filter app modules by parent path in analyze goal

### DIFF
--- a/plugin/src/main/java/org/bonitasoft/plugin/analyze/AnalyzeBonitaDependencyMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/analyze/AnalyzeBonitaDependencyMojo.java
@@ -190,9 +190,21 @@ public class AnalyzeBonitaDependencyMojo extends AbstractMojo {
     }
 
     MavenProject findAppModuleProject() throws MojoExecutionException {
-        return reactorProjects.size() == 1 ? project
-                : reactorProjects.stream().filter(p -> p.getBasedir().getName().equals("app")).findFirst().orElseThrow(
-                        () -> new MojoExecutionException(String.format("Application module not found in %s",
+        if (reactorProjects.size() == 1) {
+            return project;
+        }
+
+        // Only look at projects that are children of the current project.
+        // This handles cases where multiple "app" modules exist in a larger reactor
+        // (e.g., when a Bonita project is part of a monorepo with other modules
+        // that also have an "app" subdirectory).
+        var projectBasePath = project.getBasedir().toPath();
+        return reactorProjects.stream()
+                .filter(p -> p.getBasedir().getName().equals("app"))
+                .filter(p -> p.getBasedir().toPath().startsWith(projectBasePath))
+                .findFirst()
+                .orElseThrow(() -> new MojoExecutionException(
+                        String.format("Application module not found in %s",
                                 project.getBasedir().toPath().resolve("app"))));
     }
 

--- a/plugin/src/test/java/org/bonitasoft/plugin/analyze/AnalyzeBonitaDependencyMojoTest.java
+++ b/plugin/src/test/java/org/bonitasoft/plugin/analyze/AnalyzeBonitaDependencyMojoTest.java
@@ -236,4 +236,94 @@ class AnalyzeBonitaDependencyMojoTest {
         verify(dependencyValidator).validate(project, buildingRequest);
         verify(reporter).report(any());
     }
+
+    @Test
+    void should_find_app_module_under_current_project_when_multiple_app_modules_exist() throws Exception {
+        // Given: A reactor with multiple "app" modules from different parent projects
+        // This simulates a monorepo where:
+        // - /monorepo/services/core/app exists (belongs to core project)
+        // - /monorepo/services/process-engine/app exists (belongs to process-engine project)
+        // When analyze goal runs on process-engine, it should find process-engine/app, not core/app
+
+        // Reset mocks to avoid UnnecessaryStubbingException (this test doesn't use artifactAnalyzerFactory)
+        Mockito.reset(artifactAnalyzerFactory);
+
+        File monorepoRoot = new File("/tmp/monorepo");
+        File processEngineDir = new File(monorepoRoot, "services/process-engine");
+        File processEngineAppDir = new File(processEngineDir, "app");
+        File coreDir = new File(monorepoRoot, "services/core");
+        File coreAppDir = new File(coreDir, "app");
+
+        // Current project is process-engine
+        MavenProject processEngineProject = mock(MavenProject.class);
+        when(processEngineProject.getBasedir()).thenReturn(processEngineDir);
+
+        // App module under process-engine (the correct one to find)
+        MavenProject processEngineAppProject = mock(MavenProject.class);
+        when(processEngineAppProject.getBasedir()).thenReturn(processEngineAppDir);
+
+        // App module under core (should NOT be selected)
+        MavenProject coreAppProject = mock(MavenProject.class);
+        when(coreAppProject.getBasedir()).thenReturn(coreAppDir);
+
+        // Configure mojo
+        mojo.project = processEngineProject;
+        // Order matters: core/app comes first in reactor (simulating alphabetical module order)
+        mojo.reactorProjects = List.of(coreAppProject, processEngineAppProject, processEngineProject);
+
+        // When
+        MavenProject foundAppModule = mojo.findAppModuleProject();
+
+        // Then: Should find process-engine/app, not core/app
+        assertThat(foundAppModule).isSameAs(processEngineAppProject);
+        assertThat(foundAppModule.getBasedir().getPath()).contains("process-engine");
+    }
+
+    @Test
+    void should_find_app_module_when_single_project_in_reactor() throws Exception {
+        // Given: A single project reactor (standalone Bonita project)
+
+        // Reset mocks to avoid UnnecessaryStubbingException (this test doesn't use artifactAnalyzerFactory)
+        Mockito.reset(artifactAnalyzerFactory);
+
+        // When reactorProjects.size() == 1, the method returns project directly without
+        // inspecting basedir, so no stubbing is needed for getBasedir()
+        MavenProject standaloneProject = mock(MavenProject.class);
+        mojo.project = standaloneProject;
+        mojo.reactorProjects = List.of(standaloneProject);
+
+        // When
+        MavenProject foundAppModule = mojo.findAppModuleProject();
+
+        // Then: Should return the project itself
+        assertThat(foundAppModule).isSameAs(standaloneProject);
+    }
+
+    @Test
+    void should_throw_when_no_app_module_found_under_current_project() {
+        // Given: A reactor where no "app" module exists under the current project
+
+        // Reset mocks to avoid UnnecessaryStubbingException (this test doesn't use artifactAnalyzerFactory)
+        Mockito.reset(artifactAnalyzerFactory);
+
+        File monorepoRoot = new File("/tmp/monorepo");
+        File processEngineDir = new File(monorepoRoot, "services/process-engine");
+        File coreDir = new File(monorepoRoot, "services/core");
+        File coreAppDir = new File(coreDir, "app");
+
+        MavenProject processEngineProject = mock(MavenProject.class);
+        when(processEngineProject.getBasedir()).thenReturn(processEngineDir);
+
+        // Only core/app exists, no process-engine/app
+        MavenProject coreAppProject = mock(MavenProject.class);
+        when(coreAppProject.getBasedir()).thenReturn(coreAppDir);
+
+        mojo.project = processEngineProject;
+        mojo.reactorProjects = List.of(coreAppProject, processEngineProject);
+
+        // When/Then
+        org.junit.jupiter.api.Assertions.assertThrows(MojoExecutionException.class, () -> {
+            mojo.findAppModuleProject();
+        });
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes the `analyze` goal to correctly identify the "app" module in reactor builds with multiple "app" modules
- Adds path-based filtering to ensure only "app" modules under the current project's basedir are considered
- Adds unit tests for the `findAppModuleProject()` method

## Problem

When running in a reactor with multiple modules named 'app' (e.g., a monorepo with `services/core/app` and `services/process-engine/app`), the analyze goal incorrectly picks the first one found instead of the one belonging to the current Bonita project.

## Solution

The `findAppModuleProject()` method now filters "app" modules to only include those whose basedir is under the current project's basedir:

```java
var projectBasePath = project.getBasedir().toPath();
return reactorProjects.stream()
        .filter(p -> p.getBasedir().getName().equals("app"))
        .filter(p -> p.getBasedir().toPath().startsWith(projectBasePath))
        .findFirst()
        .orElseThrow(...);
```

## Test Plan

- [ ] Added unit tests for `findAppModuleProject()`:
  - `should_find_app_module_under_current_project_when_multiple_app_modules_exist`
  - `should_find_app_module_when_single_project_in_reactor`
  - `should_throw_when_no_app_module_found_under_current_project`
- [ ] CI tests pass

Fixes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)