### PR TITLE
fix(it): use released version of bonita-project-assemblies

### DIFF
--- a/plugin/src/it/bdm-module-generation/pom.xml
+++ b/plugin/src/it/bdm-module-generation/pom.xml
@@ -57,7 +57,7 @@
             <dependency>
               <groupId>org.bonitasoft</groupId>
               <artifactId>bonita-project-assemblies</artifactId>
-              <version>9.0-SNAPSHOT</version>
+              <version>9.0.0</version>
             </dependency>
           </dependencies>
           <executions>


### PR DESCRIPTION
## Summary
- Use released `9.0.0` version of `bonita-project-assemblies` instead of `9.0-SNAPSHOT` in the `bdm-module-generation` integration test
- `9.0-SNAPSHOT` does not exist on Maven Central snapshots, causing the IT to fail

## Test plan
- [x] Verify `bdm-module-generation` integration test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)