### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Commit Type
-        uses: gsactions/commit-message-checker@v2
+        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee # v2.0.0
         with:
           pattern: '^\S+\((.+)\):\s(.+)$'
           flags: "gm"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,13 +36,13 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@f669191d7d1e67f08a54b0c11cf5683a9a391951 # v1.0.49
         with:
           anthropic_api_key: ${{ secrets.ORGANIZATION_ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@f669191d7d1e67f08a54b0c11cf5683a9a391951 # v1.0.49
         with:
           anthropic_api_key: ${{ secrets.ORGANIZATION_ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,11 +47,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,7 +62,7 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "temurin"
           java-version: 17
@@ -70,7 +70,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -83,6 +83,6 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -16,18 +16,18 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref }}
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "temurin"
           java-version: 17
 
       - name: Configure Git user
-        uses: bonitasoft/git-setup-action@v1
+        uses: bonitasoft/git-setup-action@9593cf641830d8eadee52875d064ab6903b8b149 # v1.1.0
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,19 +17,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.tag }}
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17
           cache: maven
 
       - name: Configure Maven Settings
-        uses: bonitasoft/maven-settings-action@v1
+        uses: bonitasoft/maven-settings-action@3278c15e4023d52bc12da9d4e1a8b49a80b40559 # v1.4.0
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,19 +28,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17
           cache: maven
 
       - name: Configure Git user
-        uses: bonitasoft/git-setup-action@v1
+        uses: bonitasoft/git-setup-action@9593cf641830d8eadee52875d064ab6903b8b149 # v1.1.0
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 

--- a/.github/workflows/workflow-PR.yml
+++ b/.github/workflows/workflow-PR.yml
@@ -18,17 +18,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17
@@ -41,7 +41,7 @@ jobs:
         run: ./mvnw -B -ntp verify sonar:sonar
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
         if: always() # always run even if the previous step fails
         with:
           report_paths: "**/target/*-reports/TEST-*.xml"

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -18,17 +18,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17
           cache: maven
 
       - name: Configure Maven Settings
-        uses: bonitasoft/maven-settings-action@v1
+        uses: bonitasoft/maven-settings-action@3278c15e4023d52bc12da9d4e1a8b49a80b40559 # v1.4.0
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions references to full commit SHAs instead of mutable tags to address SonarQube security hotspot
- Adds inline version comments for maintainability (e.g., `# v6.0.2`)
- Covers all 9 workflow files and 26 `uses:` references

### Actions pinned

| Action | Version | Files |
|--------|---------|-------|
| `actions/checkout` | v6.0.2 | all workflows |
| `actions/setup-java` | v5.2.0 | codeql, publish, publish-site, release, workflow-PR, workflow-build |
| `actions/cache` | v5.0.3 | workflow-PR |
| `anthropics/claude-code-action` | v1.0.49 | claude, claude-code-review |
| `bonitasoft/git-setup-action` | v1.1.0 | publish-site, release |
| `bonitasoft/maven-settings-action` | v1.4.0 | publish, workflow-build |
| `mikepenz/action-junit-report` | v6.2.0 | workflow-PR |
| `gsactions/commit-message-checker` | v2.0.0 | check-commit-message |
| `github/codeql-action/*` | v4.32.2 | codeql-analysis |

## Test plan
- [x] Verify CI workflows still run correctly on this PR
- [x] Confirm SonarQube no longer flags the security hotspot

🤖 Generated with [Claude Code](https://claude.com/claude-code)