### PR TITLE
chore(deps): sync DEFAULT_INSTALL_PLUGIN_VERSION with pom property

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,14 @@ No release branches are created — `gitflow:release` performs the release direc
 - **Publish site:** via [Publish Maven Site workflow](https://github.com/bonitasoft/bonita-project-maven-plugin/actions/workflows/publish-site.yml).
 - After releasing from a support branch, manually cascade merge up to newer support branches and into develop.
 
+## Coupled Versions
+
+Some Java constants must stay in sync with POM properties. When Dependabot (or a manual change) updates a POM version, update the corresponding constant too:
+
+| POM property | Java constant | File |
+|---|---|---|
+| `maven-install-plugin.version` | `DEFAULT_INSTALL_PLUGIN_VERSION` | `plugin/src/main/java/org/bonitasoft/plugin/install/InstallProjectStoreMojo.java` |
+
 ## CI/CD
 
 - GitHub Actions on push to `develop`, `support/*` and PRs

--- a/plugin/src/main/java/org/bonitasoft/plugin/install/InstallProjectStoreMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/install/InstallProjectStoreMojo.java
@@ -84,7 +84,7 @@ public class InstallProjectStoreMojo extends AbstractMojo {
     private static final String VERSION = "version";
     private static final String ARTIFACT_ID = "artifactId";
 
-    static final String DEFAULT_INSTALL_PLUGIN_VERSION = "3.1.3";
+    static final String DEFAULT_INSTALL_PLUGIN_VERSION = "3.1.4";
     static final String INITIAL_INSTALL_PLUGIN_VERSION = "2.4";
     private static final String INSTALL_PLUGIN_GROUP_ID = "org.apache.maven.plugins";
     private static final String INSTALL_PLUGIN_ARTIFACT_ID = "maven-install-plugin";


### PR DESCRIPTION
## Summary
- Bumped `DEFAULT_INSTALL_PLUGIN_VERSION` from `3.1.3` to `3.1.4` in `InstallProjectStoreMojo.java` to match the `maven-install-plugin.version` POM property
- Added a **Coupled Versions** section in `CLAUDE.md` documenting the link between the POM property and the Java constant, so future Dependabot bumps are flagged

## Test plan
- [x] Verify `./mvnw test -pl plugin -Dtest=InstallProjectStoreMojoTest` passes
- [x] Confirm no other hardcoded version constants drift from POM properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)