### PR TITLE
feat(maven): Mark all Mojos as threadSafe for parallel Maven builds

### DIFF
--- a/plugin/src/main/java/org/bonitasoft/plugin/analyze/AnalyzeBonitaDependencyMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/analyze/AnalyzeBonitaDependencyMojo.java
@@ -65,7 +65,7 @@ import org.codehaus.plexus.util.StringUtils;
  * Bonita specific extensions.
  * <p>Note: extensions in reactor must be compiled first, so we can inspect the class hierarchy.</p>
  */
-@Mojo(name = "analyze", aggregator = true)
+@Mojo(name = "analyze", aggregator = true, threadSafe = true)
 public class AnalyzeBonitaDependencyMojo extends AbstractMojo {
 
     protected final ArtifactResolver artifactResolver;

--- a/plugin/src/main/java/org/bonitasoft/plugin/bdm/module/CreateBdmModuleMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/bdm/module/CreateBdmModuleMojo.java
@@ -39,7 +39,7 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 /**
  * This mojo creates a bdm module and its submodules in the current project with a Business Object Model descriptor sample file.
  */
-@Mojo(name = "create-bdm-module", defaultPhase = LifecyclePhase.NONE)
+@Mojo(name = "create-bdm-module", defaultPhase = LifecyclePhase.NONE, threadSafe = true)
 public class CreateBdmModuleMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)

--- a/plugin/src/main/java/org/bonitasoft/plugin/build/CopyProvidedPagesMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/build/CopyProvidedPagesMojo.java
@@ -58,7 +58,7 @@ import lombok.extern.slf4j.Slf4j;
  * Finally, it copies pages artifacts to an output folder (to be packaged afterward).
  */
 @Slf4j
-@Mojo(name = "copy-provided-pages", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresProject = true)
+@Mojo(name = "copy-provided-pages", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresProject = true, threadSafe = true)
 public class CopyProvidedPagesMojo extends AbstractMojo {
 
     protected static final Map<String, DefaultArtifactCoordinate> PROVIDED_PAGES = Map.of(

--- a/plugin/src/main/java/org/bonitasoft/plugin/build/ExtractConfigurationArchiveMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/build/ExtractConfigurationArchiveMojo.java
@@ -45,7 +45,7 @@ import org.bonitasoft.plugin.MavenSessionExecutor;
  * <p>This mojo extracts parameters from all the processes found in the project into a single parameters file.</p>
  * <p>This does <b>not</b> extract parameters from a Bonita configuration archive you may have updated.</p>
  */
-@Mojo(name = "extract-configuration", aggregator = true, requiresProject = true)
+@Mojo(name = "extract-configuration", aggregator = true, requiresProject = true, threadSafe = true)
 public class ExtractConfigurationArchiveMojo extends AbstractConfigurationArchiveMojo {
 
     protected ParameterConfigurationExtractor extractor = new ParameterConfigurationExtractor();

--- a/plugin/src/main/java/org/bonitasoft/plugin/build/MergeConfigurationArchiveMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/build/MergeConfigurationArchiveMojo.java
@@ -29,7 +29,7 @@ import org.bonitasoft.bonita2bar.configuration.ParametersConfigurationMerger;
 /**
  * This mojo merges given parameters into a Bonita configuration archive.
  */
-@Mojo(name = "merge-configuration", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, aggregator = true, requiresProject = true)
+@Mojo(name = "merge-configuration", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, aggregator = true, requiresProject = true, threadSafe = true)
 public class MergeConfigurationArchiveMojo extends AbstractConfigurationArchiveMojo {
 
     protected ParametersConfigurationMerger merger = new ParametersConfigurationMerger();

--- a/plugin/src/main/java/org/bonitasoft/plugin/build/bar/BuildBarMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/build/bar/BuildBarMojo.java
@@ -61,7 +61,7 @@ import org.bonitasoft.web.designer.config.UiDesignerProperties;
 /**
  * This mojo builds Business archives from diagram sources.
  */
-@Mojo(name = "business-archive", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresProject = true, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "business-archive", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresProject = true, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 @Execute(goal = "analyze")
 public class BuildBarMojo extends AbstractBuildMojo {
 

--- a/plugin/src/main/java/org/bonitasoft/plugin/build/page/BuildUidPageMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/build/page/BuildUidPageMojo.java
@@ -32,7 +32,7 @@ import org.bonitasoft.plugin.AbstractBuildMojo;
 /**
  * This mojo builds UI designer pages from sources.
  */
-@Mojo(name = "uid-page", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresProject = false)
+@Mojo(name = "uid-page", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresProject = false, threadSafe = true)
 public class BuildUidPageMojo extends AbstractBuildMojo {
 
     private static final String[] DEFAULT_EXCLUDES = new String[] { ".metadata" };

--- a/plugin/src/main/java/org/bonitasoft/plugin/extension/CreateExtensionsModuleMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/extension/CreateExtensionsModuleMojo.java
@@ -35,7 +35,7 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 /**
  * This mojo creates an extensions module in the current project.
  */
-@Mojo(name = "create-extensions-module", defaultPhase = LifecyclePhase.NONE)
+@Mojo(name = "create-extensions-module", defaultPhase = LifecyclePhase.NONE, threadSafe = true)
 public class CreateExtensionsModuleMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)

--- a/plugin/src/main/java/org/bonitasoft/plugin/install/InstallProjectStoreMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/install/InstallProjectStoreMojo.java
@@ -77,7 +77,7 @@ import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverExcepti
  * and look for them in a project local dependency store (.store folder by default).
  * Install missing dependencies found in the local store in the local repository.
  */
-@Mojo(name = "install", defaultPhase = LifecyclePhase.NONE)
+@Mojo(name = "install", defaultPhase = LifecyclePhase.NONE, threadSafe = true)
 public class InstallProjectStoreMojo extends AbstractMojo {
 
     private static final String GROUP_ID = "groupId";

--- a/plugin/src/main/java/org/bonitasoft/plugin/validation/ValidateMojo.java
+++ b/plugin/src/main/java/org/bonitasoft/plugin/validation/ValidateMojo.java
@@ -50,7 +50,7 @@ import lombok.extern.slf4j.Slf4j;
  * </ul>
  */
 @Slf4j
-@Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE)
+@Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE, threadSafe = true)
 public class ValidateMojo extends AbstractBuildMojo {
 
     public static final String BDM_SOURCE_FILE_REGEX = "^bom.xml$";


### PR DESCRIPTION
## Summary
- Add `threadSafe = true` to all 10 Mojo `@Mojo` annotations that were missing it (2 already had it: `GenerateBdmModelSourceMojo` and `GenerateBdmDaoClientSourceMojo`)
- Eliminates the "not marked as thread-safe" warning when building Bonita projects with `mvn -T` (parallel execution)

## Context

When building a Bonita project with parallel Maven execution, users see:

```
Warning:  *****************************************************************
Warning:  * Your build is requesting parallel execution, but this         *
Warning:  * project contains the following plugin(s) that have goals not  *
Warning:  * marked as thread-safe to support parallel execution.          *
Warning:  *****************************************************************
Warning:    org.bonitasoft.maven:bonita-project-maven-plugin
```

## Why this is safe

All Mojos can be safely marked as thread-safe because:

1. **Maven creates a new Mojo instance per execution** — instances are never shared across threads, so instance fields (whether `@Parameter`, `@Component`, or `@Inject`) are not a concern
2. **Aggregator Mojos** (`analyze`, `merge-configuration`, `extract-configuration`) run only once for the entire reactor, not per-module
3. **No static mutable state** — static fields are either `final` primitives/strings, immutable collections (`Map.of()`), or idempotent system property setters
4. **Manually invoked Mojos** (`install`, `create-bdm-module`, `create-extensions-module`) have `defaultPhase = NONE` and operate on their own project context

### Mojos updated

| Mojo | Goal | Notes |
|------|------|-------|
| `AnalyzeBonitaDependencyMojo` | `analyze` | Aggregator — runs once |
| `MergeConfigurationArchiveMojo` | `merge-configuration` | Aggregator — runs once |
| `ExtractConfigurationArchiveMojo` | `extract-configuration` | Aggregator — runs once |
| `ValidateMojo` | `validate` | Only static final immutable fields |
| `BuildUidPageMojo` | `uid-page` | No shared mutable state |
| `BuildBarMojo` | `business-archive` | Per-instance fields only |
| `CopyProvidedPagesMojo` | `copy-provided-pages` | Immutable static map (`Map.of()`) |
| `InstallProjectStoreMojo` | `install` | Manually invoked, per-instance |
| `CreateBdmModuleMojo` | `create-bdm-module` | Manually invoked, per-instance |
| `CreateExtensionsModuleMojo` | `create-extensions-module` | Manually invoked, per-instance |

## Test plan

- [ ] Verify the plugin builds successfully
- [ ] Build a Bonita project with `mvn -T 1C` and confirm the thread-safety warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)