### PR TITLE
fix(release): add missing attributes for maven-site-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>pom</packaging>
   <name>Bonita Project Maven Plugin Parent</name>
   <description>Maven plug-in used for Bonita Project.</description>
-  <url>https://www.bonitasoft.com</url>
+  <url>https://bonitasoft.github.io/</url>
   <inceptionYear>2021</inceptionYear>
   <organization>
     <name>Bonitasoft</name>
@@ -39,6 +39,21 @@
     <tag>HEAD</tag>
     <url>https://github.com/bonitasoft/bonita-project-maven-plugin</url>
   </scm>
+  <issueManagement>
+    <system>jira</system>
+    <url>https://bonita.atlassian.net/jira/software/c/projects/BBPMC/issues</url>
+  </issueManagement>
+  <ciManagement>
+    <system>github</system>
+    <url>https://github.com/bonitasoft/bonita-project-maven-plugin/actions</url>
+  </ciManagement>
+  <distributionManagement>
+    <site>
+      <id>github</id>
+      <name>Github Pages</name>
+      <url>scm:git:https://github.com/bonitasoft/bonita-project-maven-plugin.git</url>
+    </site>
+  </distributionManagement>
   <properties>
     <project.scm.id>github</project.scm.id>
     <java.version>17</java.version>
@@ -62,7 +77,6 @@
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-    <maven-site-plugin.version>3.13.0</maven-site-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
     <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>


### PR DESCRIPTION
- update `url` to "https://bonitasoft.github.io/"
- add `distributionManagement` (accidentally removed)
- add `issueManagement` (accidentally removed)
- add `ciManagement` (accidentally removed)
- remove duplicated property `maven-site-plugin.version` 