### PR TITLE
chore(deps): Downgrade maven-jar-plugin to 3.4.2 and pin dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,7 @@ updates:
           - "*junit*"
           - "*test*"
           - "*mockito*"
+    ignore:
+      # Skip maven-jar-plugin 3.5.0+ due to Guice incompatibility (BPA-427)
+      - dependency-name: "*maven-jar-plugin*"
+        versions: ["[3.5.0,)"]

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <maven-scm-publish-plugin.version>3.3.0</maven-scm-publish-plugin.version>
     <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
-    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
     <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
     <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>


### PR DESCRIPTION
## Summary

`maven-jar-plugin` 3.5.0+ has a Guice incompatibility (BPA-427). This PR mirrors the fix already applied in [bonita-project#290](https://github.com/bonitasoft/bonita-project/pull/290):

- Downgrade `maven-jar-plugin` from `3.5.0` to `3.4.2` in `pom.xml`
- Add an `ignore:` block to `.github/dependabot.yml` using **Maven range syntax** `[3.5.0,)` so any 3.5.x or later release is skipped until the upstream incompatibility is resolved

> Note: dependabot's `versions:` field for the Maven ecosystem requires bracket-notation ranges, **not** npm-style wildcards (`"3.5.x"` silently no-ops). See the [GitHub Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference).

Relates to [BPA-427](https://bonitasoft.atlassian.net/browse/BPA-427)
Covers [BPA-500](https://bonitasoft.atlassian.net/browse/BPA-500)

## Test plan

- [ ] CI green on `./mvnw clean verify`
- [ ] Resolved `maven-jar-plugin` version is `3.4.2` in the build (`./mvnw help:effective-pom | grep -A1 maven-jar-plugin`)
- [ ] No new dependabot PR proposing `maven-jar-plugin` 3.5.x or later on the next scheduled run

[BPA-427]: https://bonitasoft.atlassian.net/browse/BPA-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BPA-500]: https://bonitasoft.atlassian.net/browse/BPA-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ