### PR TITLE
chore(deps): adopt the jakarta ui-designer-artifact-builder and the Groovy 4 bonita2bar

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -16,8 +16,8 @@
     <!-- Dependencies -->
     <bonita-artifacts-model.version>2.0.1</bonita-artifacts-model.version>
     <bonita-business-data-generator.version>11.1.0</bonita-business-data-generator.version>
-    <bonita-ui-designer-artifact-builder.version>1.0.10</bonita-ui-designer-artifact-builder.version>
-    <bonita2bar.version>9.0.9</bonita2bar.version>
+    <bonita-ui-designer-artifact-builder.version>2.0.0</bonita-ui-designer-artifact-builder.version>
+    <bonita2bar.version>10.0.1</bonita2bar.version>
     <cfr.version>0.152</cfr.version>
     <file-management.version>3.2.0</file-management.version>
     <maven-aether-provider.version>3.3.9</maven-aether-provider.version>


### PR DESCRIPTION
## What

Bumps the two remaining pre-jakarta Bonita artifact lines in `plugin/pom.xml`:

| Property | From | To | Status |
|---|---|---|---|
| `bonita-ui-designer-artifact-builder.version` | 1.0.10 | **2.0.0** | release in progress (bonitasoft/bonita-ui-designer-artifact-builder#288/#289 merged; release pipeline unblocked via bonitasoft/bonita-ui-designer-artifact-builder#292) |
| `bonita2bar.version` | 9.0.9 | **10.0.1** | anticipating the upcoming release (Groovy 4 toolchain line, bonitasoft/bonita-process-model#152) |

## Why

This is the deferred lockstep bump flagged in the #455 review: the plugin adopted bonita-artifacts-model 2.0.1 (jakarta) there while ui-designer-artifact-builder stayed on the javax-generation 1.0.10. The 2.0.0 line brings the jakarta validation/EL stack (Bean Validation 3.x, Hibernate Validator 8, expressly) and the Spring Boot 3.5 BOM. bonita2bar 10.0.1 aligns the BAR-building toolchain on Groovy 4, matching the engine 12.0 runtime.

Part of the Jakarta migration (epic [BPA-230](https://bonitasoft.atlassian.net/browse/BPA-230)).

## Draft status

Draft until both versions are published to Maven Central - CI cannot resolve them before that.

## Related

- bonitasoft/bonita-project#371 (same bumps on the project parent side)
- bonitasoft/bonita-ui-designer-internal#628 (UID side of the artifact-builder 2.0.0 adoption)

[BPA-230]: https://bonitasoft.atlassian.net/browse/BPA-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ